### PR TITLE
Adding Offset Parameter

### DIFF
--- a/scripts/jquery.scrollto.js
+++ b/scripts/jquery.scrollto.js
@@ -14,7 +14,7 @@
 	 * @version 1.0.1
 	 * @date August 31, 2010
 	 * @since 0.1.0, August 27, 2010
-     * @package jquery-scrollto {@link http://www.balupton/projects/jquery-scrollto}
+	 * @package jquery-scrollto {@link http://www.balupton/projects/jquery-scrollto}
 	 * @author Benjamin "balupton" Lupton {@link http://www.balupton.com}
 	 * @copyright (c) 2010 Benjamin Arthur Lupton {@link http://www.balupton.com}
 	 * @license GNU Affero General Public License version 3 {@link http://www.gnu.org/licenses/agpl-3.0.html}
@@ -28,7 +28,8 @@
 				duration: 400,
 				easing: 'swing',
 				callback: undefined,
-				durationMode: 'each'
+				durationMode: 'each',
+				offset: 0
 			},
 
 			/**
@@ -53,7 +54,7 @@
 				var ScrollTo = $.ScrollTo;
 
 				// Determine the Scroll
-	    		var	collection = collections.pop(),
+				var	collection = collections.pop(),
 					$container = collection.$container,
 					$target = collection.$target;
 
@@ -72,7 +73,7 @@
 				// Determine the Offsets
 				var	startOffset = $inline.offset().top,
 					targetOffset = $target.offset().top,
-					offsetDifference = targetOffset - startOffset;
+					offsetDifference = targetOffset - startOffset - parseInt(config.offset);
 
 				// Reset the Inline Element of the Container
 				$inline.remove();


### PR DESCRIPTION
I've added in an offset parameter so you can specify how far the specified element should be from the top of the page.  I needed this in my latest project where the top menu was fixed and 60px tall.  When I scrolled down to a specific element, ScrollTo would stop when the element was underneath the top menu.  The offset makes it so ScrollTo will stop an offset amount of pixels before the element.  It also accepts a string like '60px' so no worries about the format of how it's passed in.  As long as the number is first.
