### PR TITLE
Fixed Firefox and added custom offset

### DIFF
--- a/scripts/jquery.scrollto.js
+++ b/scripts/jquery.scrollto.js
@@ -28,7 +28,8 @@
 				duration: 400,
 				easing: 'swing',
 				callback: undefined,
-				durationMode: 'each'
+				durationMode: 'each',
+        customOffset: 0
 			},
 
 			/**
@@ -95,9 +96,14 @@
 					return true;
 				};
 
+        // Firefox stores the overflow at the html level, unless specifically styled to behave differently.
+        if($container[0].tagName === "BODY" && $.browser.mozilla){
+          $container = $('html');
+        }
+
 				// Perform the Scroll
 				$container.animate({
-					'scrollTop': offsetDifference+'px'
+					'scrollTop': offsetDifference - config.customOffset + 'px'
 				}, config.duration, config.easing, callback);
 
 				// Return true


### PR DESCRIPTION
i'm surprised nobody complained, yet. but your script doesn't seem to work in the current firefox (didn't test the old ones, maybe some implementation detail changed...)

see http://stackoverflow.com/questions/8149155/animate-scrolltop-not-working-in-firefox

Also: i added the ability to pass in a custom-offset for finetuning.
