### PR TITLE
Fixes balupton#2: Firefox actually stores overflow at html level

### DIFF
--- a/scripts/jquery.scrollto.js
+++ b/scripts/jquery.scrollto.js
@@ -95,6 +95,11 @@
 					return true;
 				};
 
+        // Firefox stores the overflow at the html level, unless specifically styled to behave differently.
+        if($container[0].tagName === "BODY" && $.browser.mozilla){
+          $container = $('html');
+        }
+
 				// Perform the Scroll
 				$container.animate({
 					'scrollTop': offsetDifference+'px'


### PR DESCRIPTION
This is a clean port of balupton#6 patch by @pshizzle without the custom offset.
