### PR TITLE
Added Mozilla scroll jumping workaround

### DIFF
--- a/scripts/resources/jquery.scrollto.js
+++ b/scripts/resources/jquery.scrollto.js
@@ -141,7 +141,8 @@
 			}
 
 			// Perform the scroll
-			if ( $.browser.safari && container === document.body ) {
+			if ( $.browser.mozilla && container === document.body.parentElement ||
+					 $.browser.safari && container === document.body ) {
 				window.scrollTo(scrollOptions.scrollLeft, scrollOptions.scrollTop);
 				callback();
 			}


### PR DESCRIPTION
Added workaround for Mozilla as well, in reference to [#8](https://github.com/balupton/jquery-scrollto/issues/8)
