### PR TITLE
Scroll height vs container width

### DIFF
--- a/src/documents/lib/jquery-scrollto.js
+++ b/src/documents/lib/jquery-scrollto.js
@@ -167,7 +167,7 @@ umd: true
 			}
 
 			// Check to see if the scroll is necessary
-			if ( $container.prop('scrollHeight') === $container.width() ) {
+			if ( $container.prop('scrollHeight') === $container.height() ) {
 				delete scrollOptions.scrollTop;
 			}
 			if ( $container.prop('scrollWidth') === $container.width() ) {


### PR DESCRIPTION
This fixes an issue where if the container's scrollable height is equal to the container width, no vertical scrolling occurs.