### PR TITLE
Switching out UMD tag for actual UMD code

### DIFF
--- a/src/documents/lib/jquery-scrollto.js
+++ b/src/documents/lib/jquery-scrollto.js
@@ -1,8 +1,10 @@
----
-umd: true
----
-
-(function(){
+/*global define:false require:false */
+(function (name, context, definition) {
+    if ( typeof module !== 'undefined' && module.exports ) module.exports = definition();
+    else if ( typeof define === 'function' && define.amd ) define(definition);
+    else if ( typeof provide === 'function' ) provide(name, definition());
+    else context[name] = definition();
+})('jquery-scrollto', this, function () {
 	// Prepare
 	var jQuery, $, ScrollTo;
 	jQuery = $ = window.jQuery || require('jquery');
@@ -257,4 +259,4 @@ umd: true
 
 	// Export
 	return ScrollTo;
-}).call(this);
+});


### PR DESCRIPTION
This replaces the default UMD tag that would be interpreted by a compiler for the actual code it would put in place. This will enable people who clone this code to be able to run the latest without needing to have the tool on hand.